### PR TITLE
fix: change renderValue property from selected.name to selected.value

### DIFF
--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -173,7 +173,7 @@ export class Select extends React.Component {
       );
     }
 
-    return selected ? renderValue(selected.value) : renderValue(value || placeholder);
+    return selected ? renderValue(selected) : renderValue({ name: value || placeholder });
   }
 
   isOpenChange = () => {
@@ -441,6 +441,6 @@ Select.defaultProps = {
   className: '',
   nothingFoundText: 'Nothing found',
   renderOption: option => option.name,
-  renderValue: value => value,
+  renderValue: selected => selected.name,
   icon: 'thick',
 };

--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -173,7 +173,7 @@ export class Select extends React.Component {
       );
     }
 
-    return selected ? renderValue(selected.name) : renderValue(value || placeholder);
+    return selected ? renderValue(selected.value) : renderValue(value || placeholder);
   }
 
   isOpenChange = () => {


### PR DESCRIPTION
In Select component, when we call renderValue prop, we pass name as an argument, which is not uniquely identify select box item, instead we can pass selected item as an argument, which is an object, which has name and value, properties. The value property uniquely identify selected item. So when we want to pass render value as props, we can get selected item as an parameter of function and implement some logic related to uniqueness.