### PR TITLE
Add deployment to github pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,19 @@ install:
 script:
   - npm run lint
   - npm run build
+  - npm run build-storybook
 
 deploy:
-  provider: script
-  skip_cleanup: true
-  on:
-    branch: master
-  script:
-    - npx semantic-release
+  - provider: script
+    skip_cleanup: true
+    on:
+      branch: master
+    script:
+      - npx semantic-release
+  - provider: pages
+    skip-cleanup: true
+    github-token: $GH_TOKEN
+    local_dir: docs
+    target_branch: gh-pages
+    on:
+      branch: master

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "eslint ./src/**/**.js",
     "storybook": "start-storybook -p 9001 -c .storybook",
-    "build-storybook": "build-storybook -c .storybook -o .out",
+    "build-storybook": "build-storybook -c .storybook -o ./docs",
     "clean": "rimraf lib/*",
     "build": "npm run clean && babel src --out-dir lib --copy-files",
     "prepare": "npm run build"


### PR DESCRIPTION
Adding deployment to GitHub pages.

On every push to master, Travis will build the static version of StoryBook and push to `gh-pages` branch. Repo will be configured to pick up the `/docs` folder of the branch and deploy to Github Pages.