### PR TITLE
fix: fix select box error, after reinitialization of component

### DIFF
--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -51,7 +51,7 @@ export class Select extends React.Component {
     }));
 
     if (!multiple) {
-      if (prevProps.value !== value && selected.value !== value) {
+      if (prevProps.value !== value && (!selected || selected.value !== value)) {
         this.handleSelectChange(value);
       }
     } else if (


### PR DESCRIPTION
When we reinitialize select box, but in that time, there are no selected value, the react calls Select component's componentDidUpdate. In this function, there are condition which checks if selected value not equal to newly selected value `selected.value !== value`. But here, when we reinitialize form and select component not have selected value, The JS throws exception `Can not read property value of undefined`. I add check condition for checking if there are no selected value or selected.value not equal to the new value. `!selected || selected.value !== value`