### PR TITLE
feat: add prop on DateInput and DatePicker for defining disabled days

### DIFF
--- a/src/DateInput/index.js
+++ b/src/DateInput/index.js
@@ -121,6 +121,7 @@ export class DateInput extends React.Component {
       trigger,
       view,
       hasError,
+      disabledDays,
       ...props
     } = this.props;
 
@@ -148,6 +149,7 @@ export class DateInput extends React.Component {
               localeUtils={localeUtils}
               monthsShort={monthsShort}
               view={view}
+              disabledDays={disabledDays}
             />
           )}
           onTargetEvent={this.handleTargetEvent}
@@ -225,6 +227,12 @@ DateInput.propTypes = {
     formatWeekdayShort: PropTypes.func.isRequired,
     getFirstDayOfWeek: PropTypes.func.isRequired,
   }),
+  /** Date | Array of dates | function, decide which days should be disabled */
+  disabledDays: PropTypes.oneOfType([
+    PropTypes.instanceOf(Date),
+    PropTypes.arrayOf(PropTypes.instanceOf(Date)),
+    PropTypes.func,
+  ]),
   /** Array of strings, months short names */
   monthsShort: PropTypes.array,
   /** String, action that is opening date picker */
@@ -247,4 +255,5 @@ DateInput.defaultProps = {
   view: 'day',
   style: undefined,
   value: undefined,
+  disabledDays: undefined,
 };

--- a/src/DatePicker/index.js
+++ b/src/DatePicker/index.js
@@ -112,6 +112,7 @@ export class DatePicker extends React.Component {
       className,
       style,
       onChange,
+      disabledDays,
       ...props
     } = this.props;
     const { view, year } = this.state;
@@ -176,6 +177,7 @@ export class DatePicker extends React.Component {
             showOutsideDays={showOutsideDays}
             style={style}
             months={months}
+            disabledDays={disabledDays}
             {...otherProps}
           />
         )}
@@ -239,6 +241,12 @@ DatePicker.propTypes = {
     formatWeekdayShort: PropTypes.func.isRequired,
     getFirstDayOfWeek: PropTypes.func.isRequired,
   }),
+  /** Date | Array of dates | function, decide which days should be disabled */
+  disabledDays: PropTypes.oneOfType([
+    PropTypes.instanceOf(Date),
+    PropTypes.arrayOf(PropTypes.instanceOf(Date)),
+    PropTypes.func,
+  ]),
   /** Array of strings, months names */
   months: PropTypes.array,
   /** Array of strings, months short names */
@@ -262,4 +270,5 @@ DatePicker.defaultProps = {
   onChange: null,
   className: '',
   style: undefined,
+  disabledDays: undefined,
 };


### PR DESCRIPTION
disabledDays is a prop, which was defining which days should be disabled in DatePcker | DateInput.
disabledDays can be Date type object, array of dates, and function predicate, which takes as an argument current date and return boolean value, by which date picker defines days, that should be disabled.