### PR TITLE
feat: add class for disabled days

### DIFF
--- a/src/DatePicker/datePicker.css
+++ b/src/DatePicker/datePicker.css
@@ -95,6 +95,12 @@ abbr {
   border: 1px solid transparent;
 }
 
+.disabled,
+.disabled:hover {
+  color: var(--date-picker-disabled-color);
+  border: 1px solid transparent !important;
+}
+
 .dayPickerDay:focus {
   outline: none;
 }

--- a/src/DatePicker/index.js
+++ b/src/DatePicker/index.js
@@ -57,7 +57,12 @@ export class DatePicker extends React.Component {
     });
   };
 
-  handleDayClick = (day) => {
+  handleDayClick = (day, modifiers = {}) => {
+    const dayPickerDefaultClasses = DayPicker.defaultProps.classNames;
+    const key = `${dayPickerDefaultClasses.day} ${styles.disabled}`;
+    if (modifiers[key]) {
+      return;
+    }
     const { onChange } = this.props;
     onChange(day);
   };
@@ -142,6 +147,7 @@ export class DatePicker extends React.Component {
       weekdaysRow: `${dayPickerDefaultClasses.weekdaysRow} ${styles.dayPickerWeekdaysRow}`,
       week: `${dayPickerDefaultClasses.week} ${styles.dayPickerWeek}`,
       day: `${dayPickerDefaultClasses.day} ${styles.dayPickerDay}`,
+      disabled: `${dayPickerDefaultClasses.day} ${styles.disabled}`,
       outside: `${styles.dayPickerDayOutside}`,
       today: `${styles.dayPickerToday}`,
       selected: `${styles.dayPickerSelectedDay}`,

--- a/src/defaults.css
+++ b/src/defaults.css
@@ -287,6 +287,7 @@
   --date-picker-month-color: var(--primary-color);
   --date-picker-selected-color: var(--neutral-white);
   --date-picker-selected-background-color-hover: var(--primary-color-dark);
+  --date-picker-disabled-color: var(--disabled-color);
   --date-picker-border-radius: 5px;
   --date-picker-width: 364px;
   --date-picker-day-picker-width: 100%;
@@ -296,6 +297,7 @@
   --date-picker-month-margin: 0;
   --date-picker-month-width: 100%;
   --date-picker-weekdays-margin: 16px 0 7px;
+  --date-picker-weekdays-row-padding: 0 7px;
   --date-picker-weekdays-row-padding: 0 7px;
   --date-picker-week-padding: 0 7px;
   --date-picker-weekday-padding: 11px 0;


### PR DESCRIPTION
When we define disabled days, the react-day-picker set class name called disabled, using library modifiers we can modify class name and implement custom class name for disabled state. also added on click checking for disabled date. if day has disabled class name, then we prevent click action.